### PR TITLE
Allow .ts import paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "specstack": "dist/cli/generate.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.4.0",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.3",
@@ -511,6 +512,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.4.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,11 @@
     "outDir": "dist",
     "rootDir": ".",
     "strict": true,
+    "types": ["node"],
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true
   },
   "include": [
     "cli",


### PR DESCRIPTION
## Summary
- enable `allowImportingTsExtensions` so TypeScript accepts `.ts` import paths
- rewrite import extensions to `.js` on emit
- install typings for `js-yaml`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f4cb435f08328b4694663d5c409c4