### PR TITLE
Handle missing OpenAPI spec

### DIFF
--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -12,6 +12,10 @@ import path from 'path';
 export function parseOpenAPI(filePath: string): SpecIR {
   console.log(`Parsing OpenAPI spec from: ${filePath}`);
 
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`OpenAPI file not found: ${filePath}`);
+  }
+
   const fileContent = fs.readFileSync(filePath, 'utf-8');
   const openapiDoc = yaml.load(fileContent) as any;
 

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -39,4 +39,9 @@ describe('parseOpenAPI', () => {
       responseBodyType: 'Pet',
     });
   });
+
+  test('throws a clear error when file is missing', () => {
+    const badPath = path.join(__dirname, 'missing_file.yaml');
+    expect(() => parseOpenAPI(badPath)).toThrowError('OpenAPI file not found');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `parseOpenAPI` throws a user-friendly error when the file doesn't exist
- test missing file behaviour in parser tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841977d966483288ca7680ec469fbec