### PR TITLE
Fix imports for NodeNext build

### DIFF
--- a/cli/generate.ts
+++ b/cli/generate.ts
@@ -1,9 +1,9 @@
 // cli/generate.ts
 
-import { parseOpenAPI } from '../parser/openapi_parser.ts';
-import { generateCreateTableSQL, generateCreateFunctionSQL } from '../transformer/db_transformer.ts';
-import { generateUseHook } from '../transformer/frontend_transformer.ts';
-import { writeToFile } from '../generator/file_writer.ts';
+import { parseOpenAPI } from '../parser/openapi_parser.js';
+import { generateCreateTableSQL, generateCreateFunctionSQL } from '../transformer/db_transformer.js';
+import { generateUseHook } from '../transformer/frontend_transformer.js';
+import { writeToFile } from '../generator/file_writer.js';
 import { join } from 'path';
 
 const args = process.argv.slice(2);

--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -1,6 +1,6 @@
 // parser/openapi_parser.ts
 
-import { SpecIR, TableSpec, ColumnSpec, FunctionSpec, ParamSpec } from '../types/specir.ts';
+import { SpecIR, TableSpec, ColumnSpec, FunctionSpec, ParamSpec } from '../types/specir.js';
 import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';

--- a/transformer/db_transformer.ts
+++ b/transformer/db_transformer.ts
@@ -1,6 +1,6 @@
 // transformer/db_transformer.ts
 
-import { TableSpec, FunctionSpec, ColumnSpec } from '../types/specir.ts';
+import { TableSpec, FunctionSpec, ColumnSpec } from '../types/specir.js';
 
 /**
  * Generates a full CREATE TABLE SQL statement from a TableSpec.

--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -1,6 +1,6 @@
 // transformer/frontend_transformer.ts
 
-import { FunctionSpec } from '../types/specir.ts';
+import { FunctionSpec } from '../types/specir.js';
 
 /**
  * Generates a React Query hook for a given API function.


### PR DESCRIPTION
## Summary
- update relative imports in generator and transformers to use `.js`
- ensure TypeScript build works without `allowImportingTsExtensions`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841977d3aa48328ab58a2cb574db628