### PR TITLE
Fix sample app to use generated hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Optional: specify output directory
 npm run dev <path/to/your/openAPI/spec.yaml> ./custom_output_dir
 ```
 
+Running the command above will create React Query hooks under `generated/frontend/src/hooks`.
+Import these hooks in your React components (e.g., `useGetPetById`) after generation:
+
+```ts
+import { useGetPetById } from '../generated/frontend/src/hooks';
+```
+
 ---
 
 ## 🛠️ How It Works

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,23 +1,25 @@
 // frontend/src/App.tsx
 
-import { usePets } from './hooks/usePets';
+// Generated React Query hooks live under ../../generated after running the generator
+import { useGetPetById } from '../../generated/frontend/src/hooks';
 
 function App() {
-  const { pets, isLoading, isError } = usePets();
+  // Example usage fetching the pet with id=1
+  const { data: pet, isLoading, isError } = useGetPetById({ id: 1 });
 
   if (isLoading) return <div>Loading...</div>;
-  if (isError) return <div>Error loading pets</div>;
+  if (isError) return <div>Error loading pet</div>;
 
   return (
     <div className="p-8">
       <h1>Petstore</h1>
-      <ul>
-        {pets.map((pet: any) => (
-          <li key={pet.id}>
-            {pet.name} ({pet.tag})
-          </li>
-        ))}
-      </ul>
+      {pet ? (
+        <div>
+          {pet.name} ({pet.tag})
+        </div>
+      ) : (
+        <div>No pet found</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- switch the demo `App` component to use the generated `useGetPetById` hook
- document how to generate and import hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685969e4c4388328bc1ef5f1d637d573