### PR TITLE
Isolate query params in useHook generator

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -21,6 +21,18 @@ describe('generation functions', () => {
     responseBodyType: 'Pet',
   };
 
+  const funcWithQuery: FunctionSpec = {
+    name: 'searchPets',
+    method: 'GET',
+    path: '/pets',
+    params: [
+      { name: 'tag', in: 'query', required: false, type: 'string' },
+      { name: 'limit', in: 'query', required: false, type: 'integer' },
+    ],
+    requestBodyType: undefined,
+    responseBodyType: 'Pet[]',
+  };
+
   test('generateCreateTableSQL', () => {
     const sql = generateCreateTableSQL(table);
     expect(sql).toBe(`CREATE TABLE IF NOT EXISTS Pet (
@@ -46,5 +58,11 @@ $$;`);
     expect(hook).toContain("useGetPetById");
     expect(hook).toContain("useQuery(['getPetById']");
     expect(hook).toContain("fetch(`/pets/${params.id}");
+  });
+
+  test('generateUseHook with query params', () => {
+    const hook = generateUseHook(funcWithQuery);
+    expect(hook).toContain('const queryParamsObj = { tag: params.tag, limit: params.limit }');
+    expect(hook).toContain('new URLSearchParams(queryParamsObj)');
   });
 });

--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -23,7 +23,8 @@ export function generateUseHook(func: FunctionSpec): string {
 
   const queryFn = func.method === 'GET'
     ? `async (${needsParams ? '{ params }' : ''}) => {
-    const query = new URLSearchParams(${queryParams.length > 0 ? 'params' : '{}'}).toString();
+    const queryParamsObj = ${queryParams.length > 0 ? `{ ${queryParams.map(p => `${p.name}: params.${p.name}`).join(', ')} }` : '{}'};
+    const query = new URLSearchParams(queryParamsObj).toString();
     const response = await fetch(\`${urlPath}\${query ? '?' + query : ''}\`);
     return response.json();
   }`


### PR DESCRIPTION
## Summary
- only send query parameters to `URLSearchParams`
- verify query-only param handling in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685969e793bc83289c004e8b846da9eb