### PR TITLE
Add react-query to frontend and update generator

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.81.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "swr": "^2.3.3"
@@ -1294,6 +1295,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.2.tgz",
+      "integrity": "sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.2.tgz",
+      "integrity": "sha512-pe8kFlTrL2zFLlcAj2kZk9UaYYHDk9/1hg9EBaoO3cxDhOZf1FRGJeziSXKrVZyxIfs7b3aoOj/bw7Lie0mDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.81.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "@tanstack/react-query": "^5.81.2",
     "swr": "^2.3.3"
   },
   "devDependencies": {

--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -44,7 +44,7 @@ $$;`);
   test('generateUseHook', () => {
     const hook = generateUseHook(func);
     expect(hook).toContain("useGetPetById");
-    expect(hook).toContain("useQuery(['getPetById']");
+    expect(hook).toContain("useQuery({ queryKey: ['getPetById']");
     expect(hook).toContain("fetch(`/pets/${params.id}");
   });
 });

--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -16,18 +16,18 @@ export function generateUseHook(func: FunctionSpec): string {
   const paramsInterface = needsParams ? `params: {
     ${urlParams.map(p => `${p.name}: ${mapTypeToTS(p.type)}`).join(';\n    ')}
     ${queryParams.map(p => `${p.name}?: ${mapTypeToTS(p.type)}`).join(';\n    ')}
-    ${func.requestBodyType ? `body: ${func.requestBodyType}` : ''}
+    ${func.requestBodyType ? `body: any` : ''}
   }` : '';
 
   const urlPath = buildUrlTemplate(func.path, urlParams);
 
   const queryFn = func.method === 'GET'
-    ? `async (${needsParams ? '{ params }' : ''}) => {
+    ? `async () => {
     const query = new URLSearchParams(${queryParams.length > 0 ? 'params' : '{}'}).toString();
     const response = await fetch(\`${urlPath}\${query ? '?' + query : ''}\`);
     return response.json();
   }`
-    : `async (${needsParams ? '{ params }' : ''}) => {
+    : `async () => {
     const response = await fetch(\`${urlPath}\`, {
       method: '${func.method}',
       headers: { 'Content-Type': 'application/json' },
@@ -42,8 +42,8 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 export function ${hookName}(${needsParams ? paramsInterface : ''}) {
   return ${
     func.method === 'GET'
-      ? `useQuery(['${queryKey}'], ${queryFn})`
-      : `useMutation(${queryFn})`
+      ? `useQuery({ queryKey: ['${queryKey}'], queryFn: ${queryFn} })`
+      : `useMutation({ mutationFn: ${queryFn} })`
   };
 }
 `.trim();


### PR DESCRIPTION
## Summary
- add `@tanstack/react-query` to frontend dependencies
- adjust React hook generator for React Query v5
- keep generated params untyped to compile
- update tests

## Testing
- `npm test`
- `npx tsc src/hooks/useGetPetById.ts --lib DOM,ES2022 --jsx react --moduleResolution nodenext --module nodenext --skipLibCheck --noEmit`
- `npx tsc src/hooks/useCreatePet.ts --lib DOM,ES2022 --jsx react --moduleResolution nodenext --module nodenext --skipLibCheck --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685969e60bec832899313919d590c202