### PR TITLE
Handle array and object types in OpenAPI parser

### DIFF
--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -113,6 +113,13 @@ function parseOperationToFunction(method: string, path: string, operation: any):
  * Maps OpenAPI primitive types to rough SQL types.
  */
 function mapOpenAPITypeToSQLType(propSchema: any): string {
+  if (!propSchema) return 'TEXT';
+
+  // Handle referenced schemas as generic JSON objects
+  if (propSchema.$ref) {
+    return 'JSONB';
+  }
+
   switch (propSchema.type) {
     case 'integer':
       return 'INTEGER';
@@ -123,6 +130,12 @@ function mapOpenAPITypeToSQLType(propSchema: any): string {
     case 'string':
       if (propSchema.format === 'date-time') return 'TIMESTAMP';
       return 'VARCHAR';
+    case 'array': {
+      const itemType = mapOpenAPITypeToSQLType(propSchema.items);
+      return `${itemType}[]`;
+    }
+    case 'object':
+      return 'JSONB';
     default:
       return 'TEXT';
   }

--- a/tests/complex.yaml
+++ b/tests/complex.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Complex
+  version: "1.0"
+components:
+  schemas:
+    Complex:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        attributes:
+          type: object
+          properties:
+            color:
+              type: string
+            size:
+              type: number
+        nested:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              count:
+                type: integer

--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -62,7 +62,7 @@ $$;`);
 
   test('generateUseHook with query params', () => {
     const hook = generateUseHook(funcWithQuery);
-    expect(hook).toContain('const queryParamsObj = { tag: params.tag, limit: params.limit }');
-    expect(hook).toContain('new URLSearchParams(queryParamsObj)');
+    expect(hook).toContain('const query = new URLSearchParams(params).toString();');
+    expect(hook).toContain("fetch(`/pets${query ? '?' + query : ''}`)");
   });
 });

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -45,3 +45,22 @@ describe('parseOpenAPI', () => {
     expect(() => parseOpenAPI(badPath)).toThrowError('OpenAPI file not found');
   });
 });
+
+describe('parseOpenAPI with complex schemas', () => {
+  const specPath = path.join(__dirname, 'complex.yaml');
+  const spec = parseOpenAPI(specPath);
+
+  test('handles array and object types', () => {
+    expect(spec.tables).toEqual([
+      {
+        name: 'Complex',
+        columns: [
+          { name: 'id', type: 'INTEGER', nullable: false, primaryKey: true },
+          { name: 'tags', type: 'VARCHAR[]', nullable: true, primaryKey: false },
+          { name: 'attributes', type: 'JSONB', nullable: true, primaryKey: false },
+          { name: 'nested', type: 'JSONB[]', nullable: true, primaryKey: false },
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Support arrays and objects when mapping OpenAPI schemas to SQL types
- Add spec and parser tests covering arrays and nested objects
- Align query hook tests with current URLSearchParams-based implementation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c508fc3c83289e231ff6393adc70