### PR TITLE
Ensure query params isolated in React hook generator

### DIFF
--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -23,7 +23,8 @@ export function generateUseHook(func: FunctionSpec): string {
 
   const queryFn = func.method === 'GET'
     ? `async () => {
-    const query = new URLSearchParams(${queryParams.length > 0 ? 'params' : '{}'}).toString();
+    const queryParamsObj = ${queryParams.length > 0 ? `{ ${queryParams.map(p => `${p.name}: params.${p.name}`).join(', ')} }` : '{}'};
+    const query = new URLSearchParams(queryParamsObj).toString();
     const response = await fetch(\`${urlPath}\${query ? '?' + query : ''}\`);
     return response.json();
   }`


### PR DESCRIPTION
## Summary
- Build a `queryParamsObj` with only query parameters in `generateUseHook`
- Construct query strings from this object so path params and body data are excluded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c504ae188328a6fad347386ee442