### PR TITLE
test: update query param expectations

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -75,8 +75,8 @@ describe('generation functions', () => {
 
   test('generateUseHook with query params', () => {
     const hook = generateUseHook(funcWithQuery);
-    expect(hook).toContain('new URLSearchParams(params).toString()');
+    expect(hook).toContain('const queryParamsObj = { tag: params.tag, limit: params.limit };');
+    expect(hook).toContain('const query = new URLSearchParams(queryParamsObj).toString();');
     expect(hook).toContain("fetch(`/pets${query ? '?' + query : ''}`)");
-    expect(hook).toContain('const query = new URLSearchParams(params).toString();');
   });
 });


### PR DESCRIPTION
## Summary
- adjust generation hook tests for query param object and URL construction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d27d7260483288663a30ea5c81666