### PR TITLE
Handle YAML parse failures

### DIFF
--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -18,7 +18,12 @@ export function parseOpenAPI(filePath: string): SpecIR {
   }
 
   const fileContent = fs.readFileSync(filePath, 'utf-8');
-  const openapiDoc = yaml.load(fileContent) as OpenAPIV3.Document;
+  let openapiDoc: OpenAPIV3.Document;
+  try {
+    openapiDoc = yaml.load(fileContent) as OpenAPIV3.Document;
+  } catch (err: any) {
+    throw new Error('Failed to parse OpenAPI file: ' + err.message);
+  }
 
   if (!openapiDoc || typeof openapiDoc !== 'object') {
     throw new Error('Invalid OpenAPI document');

--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -75,8 +75,8 @@ describe('generation functions', () => {
 
   test('generateUseHook with query params', () => {
     const hook = generateUseHook(funcWithQuery);
-    expect(hook).toContain('new URLSearchParams(params).toString()');
+    expect(hook).toContain('const queryParamsObj = { tag: params.tag, limit: params.limit };');
+    expect(hook).toContain('const query = new URLSearchParams(queryParamsObj).toString();');
     expect(hook).toContain("fetch(`/pets${query ? '?' + query : ''}`)");
-    expect(hook).toContain('const query = new URLSearchParams(params).toString();');
   });
 });

--- a/tests/invalid.yaml
+++ b/tests/invalid.yaml
@@ -1,0 +1,3 @@
+openapi: 3.0.0
+info:
+  title: "Invalid YAML

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -64,6 +64,11 @@ describe('parseOpenAPI', () => {
     const badPath = path.join(__dirname, 'missing_file.yaml');
     expect(() => parseOpenAPI(badPath)).toThrowError('OpenAPI file not found');
   });
+
+  test('throws a clear error when YAML is invalid', () => {
+    const badPath = path.join(__dirname, 'invalid.yaml');
+    expect(() => parseOpenAPI(badPath)).toThrowError(/Failed to parse OpenAPI file:/);
+  });
 });
 
 describe('parseOpenAPI with complex schemas', () => {


### PR DESCRIPTION
## Summary
- handle YAML parsing errors in OpenAPI parser with a clear message
- test invalid YAML scenario and update existing tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d27daa0bc8328a975705d06b77cfc