### PR TITLE
Support PUT, PATCH, and DELETE SQL generation

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -45,6 +45,41 @@ describe('generation functions', () => {
     responseBodyType: 'Pet[]',
   };
 
+  const updateFunc: FunctionSpec = {
+    name: 'updatePet',
+    method: 'PUT',
+    path: '/pets/{id}',
+    params: [
+      { name: 'id', in: 'path', required: true, type: 'integer' },
+      { name: 'name', in: 'query', required: false, type: 'string' },
+    ],
+    requestBodyType: 'Pet',
+    responseBodyType: 'Pet',
+  };
+
+  const patchFunc: FunctionSpec = {
+    name: 'patchPet',
+    method: 'PATCH',
+    path: '/pets/{id}',
+    params: [
+      { name: 'id', in: 'path', required: true, type: 'integer' },
+      { name: 'tag', in: 'query', required: false, type: 'string' },
+    ],
+    requestBodyType: 'Pet',
+    responseBodyType: 'Pet',
+  };
+
+  const deleteFunc: FunctionSpec = {
+    name: 'deletePet',
+    method: 'DELETE',
+    path: '/pets/{id}',
+    params: [
+      { name: 'id', in: 'path', required: true, type: 'integer' },
+    ],
+    requestBodyType: 'Pet',
+    responseBodyType: undefined,
+  };
+
   test('generateCreateTableSQL', () => {
     const sql = generateCreateTableSQL(table);
     expect(sql).toBe(`CREATE TABLE IF NOT EXISTS Pet (
@@ -66,6 +101,24 @@ describe('generation functions', () => {
     expect(sql).toContain('RETURNING *');
   });
 
+  test('generateCreateFunctionSQL for PUT', () => {
+    const sql = generateCreateFunctionSQL(updateFunc);
+    expect(sql).toContain('UPDATE Pet SET name = name WHERE id = id');
+    expect(sql).toContain('RETURNING *');
+  });
+
+  test('generateCreateFunctionSQL for PATCH', () => {
+    const sql = generateCreateFunctionSQL(patchFunc);
+    expect(sql).toContain('UPDATE Pet SET tag = tag WHERE id = id');
+    expect(sql).toContain('RETURNING *');
+  });
+
+  test('generateCreateFunctionSQL for DELETE', () => {
+    const sql = generateCreateFunctionSQL(deleteFunc);
+    expect(sql).toContain('DELETE FROM Pet WHERE id = id');
+    expect(sql).not.toContain('RETURNING *');
+  });
+
   test('generateUseHook', () => {
     const hook = generateUseHook(func);
     expect(hook).toContain("useGetPetById");
@@ -75,8 +128,9 @@ describe('generation functions', () => {
 
   test('generateUseHook with query params', () => {
     const hook = generateUseHook(funcWithQuery);
-    expect(hook).toContain('new URLSearchParams(params).toString()');
+    expect(hook).toContain('const queryParamsObj = { tag: params.tag, limit: params.limit };');
+    expect(hook).toContain('new URLSearchParams(queryParamsObj).toString()');
     expect(hook).toContain("fetch(`/pets${query ? '?' + query : ''}`)");
-    expect(hook).toContain('const query = new URLSearchParams(params).toString();');
+    expect(hook).toContain('const query = new URLSearchParams(queryParamsObj).toString();');
   });
 });

--- a/transformer/db_transformer.ts
+++ b/transformer/db_transformer.ts
@@ -76,6 +76,23 @@ function generateFunctionBodySQL(func: FunctionSpec, tableName: string): string 
       }
       return `INSERT INTO ${tableName} DEFAULT VALUES${func.responseBodyType ? ' RETURNING *' : ''};`;
     }
+    case 'PUT':
+    case 'PATCH': {
+      if (paramNames.length) {
+        const [idParam, ...rest] = paramNames;
+        if (rest.length) {
+          const setClause = rest.map(name => `${name} = ${name}`).join(', ');
+          return `UPDATE ${tableName} SET ${setClause} WHERE ${idParam} = ${idParam}${func.responseBodyType ? ' RETURNING *' : ''};`;
+        }
+      }
+      return `-- TODO: Implement SQL body for ${func.name}`;
+    }
+    case 'DELETE': {
+      const whereClause = paramNames.length
+        ? ' WHERE ' + paramNames.map(name => `${name} = ${name}`).join(' AND ')
+        : '';
+      return `DELETE FROM ${tableName}${whereClause}${func.responseBodyType ? ' RETURNING *' : ''};`;
+    }
     default:
       return `-- TODO: Implement SQL body for ${func.name}`;
   }


### PR DESCRIPTION
## Summary
- extend SQL generator to emit UPDATE and DELETE statements
- add PUT/PATCH/DELETE function cases to tests
- update hook test for new query param handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d27d8914c83289ab4a79004ab16c6