### PR TITLE
feat: compute hook imports

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -68,15 +68,27 @@ describe('generation functions', () => {
 
   test('generateUseHook', () => {
     const hook = generateUseHook(func);
-    expect(hook).toContain("useGetPetById");
+    expect(hook).toContain("import { useQuery } from '@tanstack/react-query';");
+    expect(hook).not.toContain('useMutation');
+    expect(hook).toContain('useGetPetById');
     expect(hook).toContain("useQuery({ queryKey: ['getPetById']");
-    expect(hook).toContain("fetch(`/pets/${params.id}");
+    expect(hook).toContain("fetch(`/pets/${params.id}${query ? '?' + query : ''}`);");
   });
 
   test('generateUseHook with query params', () => {
     const hook = generateUseHook(funcWithQuery);
-    expect(hook).toContain('new URLSearchParams(params).toString()');
-    expect(hook).toContain("fetch(`/pets${query ? '?' + query : ''}`)");
-    expect(hook).toContain('const query = new URLSearchParams(params).toString();');
+    expect(hook).toContain("import { useQuery } from '@tanstack/react-query';");
+    expect(hook).not.toContain('useMutation');
+    expect(hook).toContain('const queryParamsObj = { tag: params.tag, limit: params.limit };');
+    expect(hook).toContain('const query = new URLSearchParams(queryParamsObj).toString();');
+    expect(hook).toContain("fetch(`/pets${query ? '?' + query : ''}`);");
+  });
+
+  test('generateUseHook for mutation', () => {
+    const hook = generateUseHook(createFunc);
+    expect(hook).toContain("import { useMutation } from '@tanstack/react-query';");
+    expect(hook).not.toContain('useQuery');
+    expect(hook).toContain('useMutation({ mutationFn:');
+    expect(hook).toContain("method: 'POST'");
   });
 });

--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -37,8 +37,10 @@ export function generateUseHook(func: FunctionSpec): string {
     return response.json();
   }`;
 
+  const importList = func.method === 'GET' ? 'useQuery' : 'useMutation';
+
   return `
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { ${importList} } from '@tanstack/react-query';
 
 export function ${hookName}(${needsParams ? paramsInterface : ''}) {
   return ${


### PR DESCRIPTION
## Summary
- compute React Query imports per HTTP method in `generateUseHook`
- ensure generated hooks import `useQuery` for GET and `useMutation` otherwise
- test generation updated to assert exact imports for queries and mutations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d27da1b548328b41411754a417e84