### PR TITLE
refactor: use async fs writes

### DIFF
--- a/cli/generate.ts
+++ b/cli/generate.ts
@@ -26,12 +26,12 @@ const frontendOut = join(outputBase, 'frontend/src/hooks');
 console.log('Generating DB schema and functions...');
 for (const table of spec.tables) {
   const sql = generateCreateTableSQL(table);
-  writeToFile(join(dbOut, `${table.name}_table.sql`), sql + '\n');
+  await writeToFile(join(dbOut, `${table.name}_table.sql`), sql + '\n');
 }
 
 for (const func of spec.functions) {
   const sql = generateCreateFunctionSQL(func);
-  writeToFile(join(dbOut, `${func.name}_function.sql`), sql + '\n');
+  await writeToFile(join(dbOut, `${func.name}_function.sql`), sql + '\n');
 }
 
 console.log('Generating frontend React hooks...');
@@ -40,14 +40,14 @@ const hookFiles: string[] = [];
 for (const func of spec.functions) {
   const hookName = `use${capitalize(func.name)}`;
   const hook = generateUseHook(func);
-  writeToFile(join(frontendOut, `${hookName}.ts`), hook);
+  await writeToFile(join(frontendOut, `${hookName}.ts`), hook);
   hookFiles.push(hookName);
 }
 
 // Generate frontend index.ts to re-export all hooks
 if (hookFiles.length > 0) {
   const indexContent = hookFiles.map(hook => `export * from './${hook}';`).join('\n');
-  writeToFile(join(frontendOut, 'index.ts'), indexContent + '\n');
+  await writeToFile(join(frontendOut, 'index.ts'), indexContent + '\n');
 }
 
 console.log('✅ Generation complete.');

--- a/generator/file_writer.ts
+++ b/generator/file_writer.ts
@@ -1,6 +1,6 @@
 // generator/file_writer.ts
 
-import { writeFileSync, mkdirSync } from 'fs';
+import { mkdir, writeFile } from 'fs/promises';
 import { dirname } from 'path';
 
 /**
@@ -8,18 +8,18 @@ import { dirname } from 'path';
  * @param filePath The file path to write to.
  * @param content The content to write.
  */
-export function writeToFile(filePath: string, content: string): void {
+export async function writeToFile(filePath: string, content: string): Promise<void> {
   const dir = dirname(filePath);
 
   try {
-    mkdirSync(dir, { recursive: true }); // make sure directory exists
+    await mkdir(dir, { recursive: true }); // make sure directory exists
   } catch (err) {
     console.error(`Failed to create directory for ${filePath}`, err);
     throw err;
   }
 
   try {
-    writeFileSync(filePath, content);
+    await writeFile(filePath, content);
     console.log(`✅ Wrote: ${filePath}`);
   } catch (err) {
     console.error(`❌ Failed to write to ${filePath}`, err);


### PR DESCRIPTION
## Summary
- use async fs.promises mkdir/writeFile in file writer
- export async writeToFile and await it in generate CLI

## Testing
- `npm test` *(fails: generation functions › generateUseHook with query params)*

------
https://chatgpt.com/codex/tasks/task_e_689d27dc157c832898d9cbf83c2e9339