### PR TITLE
feat: type request bodies in hooks

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -134,4 +134,10 @@ describe('generation functions', () => {
     expect(hook).toContain('const query = new URLSearchParams(queryParamsObj).toString();');
     expect(hook).toContain("fetch(`/pets${query ? '?' + query : ''}`)");
   });
+
+  test('generateUseHook includes typed body', () => {
+    const hook = generateUseHook(createFunc);
+    expect(hook).toContain("import type { Pet } from '../types';");
+    expect(hook).toContain('body: Pet');
+  });
 });

--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -16,7 +16,7 @@ export function generateUseHook(func: FunctionSpec): string {
   const paramsInterface = needsParams ? `params: {
     ${urlParams.map(p => `${p.name}: ${mapTypeToTS(p.type)}`).join(';\n    ')}
     ${queryParams.map(p => `${p.name}?: ${mapTypeToTS(p.type)}`).join(';\n    ')}
-    ${func.requestBodyType ? `body: any` : ''}
+    ${func.requestBodyType ? `body: ${func.requestBodyType}` : ''}
   }` : '';
 
   const urlPath = buildUrlTemplate(func.path, urlParams);
@@ -39,8 +39,12 @@ export function generateUseHook(func: FunctionSpec): string {
 
   const importList = func.method === 'GET' ? 'useQuery' : 'useMutation';
 
+  const imports = [`import { ${importList} } from '@tanstack/react-query';`,
+    func.requestBodyType ? `import type { ${func.requestBodyType} } from '../types';` : ''
+  ].filter(Boolean).join('\n');
+
   return `
-import { ${importList} } from '@tanstack/react-query';
+${imports}
 
 export function ${hookName}(${needsParams ? paramsInterface : ''}) {
   return ${


### PR DESCRIPTION
## Summary
- propagate request body types into generated React Query hooks
- import associated TypeScript models when generating hooks
- test that hooks include typed bodies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a269fa64ac832891f25f0ab92cc28b