### PR TITLE
feat: expand SQL generation for more HTTP methods

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -69,6 +69,46 @@ describe('generation functions', () => {
     responseBodyType: 'Pet',
   };
 
+  const updateFuncNoParams: FunctionSpec = {
+    name: 'updatePetNoParams',
+    method: 'PUT',
+    path: '/pets/{id}',
+    params: [
+      { name: 'id', in: 'path', required: true, type: 'integer' },
+    ],
+    requestBodyType: 'Pet',
+    responseBodyType: 'Pet',
+  };
+
+  const patchFuncNoParams: FunctionSpec = {
+    name: 'patchPetNoParams',
+    method: 'PATCH',
+    path: '/pets/{id}',
+    params: [
+      { name: 'id', in: 'path', required: true, type: 'integer' },
+    ],
+    requestBodyType: 'Pet',
+    responseBodyType: 'Pet',
+  };
+
+  const headFunc: FunctionSpec = {
+    name: 'headPets',
+    method: 'HEAD',
+    path: '/pets',
+    params: [],
+    requestBodyType: undefined,
+    responseBodyType: undefined,
+  };
+
+  const optionsFunc: FunctionSpec = {
+    name: 'optionsPets',
+    method: 'OPTIONS',
+    path: '/pets',
+    params: [],
+    requestBodyType: undefined,
+    responseBodyType: undefined,
+  };
+
   const deleteFunc: FunctionSpec = {
     name: 'deletePet',
     method: 'DELETE',
@@ -126,10 +166,29 @@ describe('generation functions', () => {
     expect(sql).toContain('RETURNING *');
   });
 
+  test('generateCreateFunctionSQL for PUT with only id param', () => {
+    const sql = generateCreateFunctionSQL(updateFuncNoParams);
+    expect(sql).toContain('UPDATE Pet SET -- no columns to update WHERE id = _id');
+    expect(sql).toContain('RETURNING *');
+  });
+
+  test('generateCreateFunctionSQL for PATCH with only id param', () => {
+    const sql = generateCreateFunctionSQL(patchFuncNoParams);
+    expect(sql).toContain('UPDATE Pet SET -- no columns to update WHERE id = _id');
+    expect(sql).toContain('RETURNING *');
+  });
+
   test('generateCreateFunctionSQL for DELETE', () => {
     const sql = generateCreateFunctionSQL(deleteFunc);
     expect(sql).toContain('DELETE FROM Pet WHERE id = _id');
     expect(sql).not.toContain('RETURNING *');
+  });
+
+  test('generateCreateFunctionSQL for unsupported methods', () => {
+    const headSql = generateCreateFunctionSQL(headFunc);
+    expect(headSql).toContain('-- Unsupported HTTP method: HEAD');
+    const optionsSql = generateCreateFunctionSQL(optionsFunc);
+    expect(optionsSql).toContain('-- Unsupported HTTP method: OPTIONS');
   });
 
   test('generateUseHook', () => {

--- a/transformer/db_transformer.ts
+++ b/transformer/db_transformer.ts
@@ -89,14 +89,12 @@ function generateFunctionBodySQL(func: FunctionSpec, tableName: string): string 
     case 'PATCH': {
       if (paramNames.length) {
         const [idParam, ...rest] = paramNames;
-        if (rest.length) {
-          const setClause = rest
-            .map(name => `${name} = ${placeholders[name]}`)
-            .join(', ');
-          return `UPDATE ${tableName} SET ${setClause} WHERE ${idParam} = ${placeholders[idParam]}${func.responseBodyType ? ' RETURNING *' : ''};`;
-        }
+        const setClause = rest.length
+          ? rest.map(name => `${name} = ${placeholders[name]}`).join(', ')
+          : '-- no columns to update';
+        return `UPDATE ${tableName} SET ${setClause} WHERE ${idParam} = ${placeholders[idParam]}${func.responseBodyType ? ' RETURNING *' : ''};`;
       }
-      return `-- TODO: Implement SQL body for ${func.name}`;
+      return `UPDATE ${tableName} SET -- no parameters provided${func.responseBodyType ? ' RETURNING *' : ''};`;
     }
     case 'DELETE': {
       const whereClause = paramNames.length
@@ -108,8 +106,10 @@ function generateFunctionBodySQL(func: FunctionSpec, tableName: string): string 
         : '';
       return `DELETE FROM ${tableName}${whereClause}${func.responseBodyType ? ' RETURNING *' : ''};`;
     }
+    case 'HEAD':
+    case 'OPTIONS':
     default:
-      return `-- TODO: Implement SQL body for ${func.name}`;
+      return `-- Unsupported HTTP method: ${func.method}`;
   }
 }
 

--- a/types/specir.ts
+++ b/types/specir.ts
@@ -39,4 +39,4 @@ export interface ParamSpec {
 }
 
 // Enumerates supported HTTP methods
-export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';


### PR DESCRIPTION
## Summary
- generate PUT/PATCH SQL with placeholder SET clause and optional RETURNING even when no update fields
- flag HEAD and OPTIONS as unsupported in SQL function bodies
- cover PUT/PATCH edge cases and unsupported methods in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c2027e1483289d3e7e2ea6431b9e