### PR TITLE
refactor: async openapi parser

### DIFF
--- a/cli/generate.ts
+++ b/cli/generate.ts
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
   try {
     console.log(`Parsing OpenAPI spec from ${openapiPath}...`);
 
-    const spec = parseOpenAPI(openapiPath);
+    const spec = await parseOpenAPI(openapiPath);
 
     const dbOut = join(outputBase, 'db');
     const frontendOut = join(outputBase, 'frontend/src/hooks');

--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -1,7 +1,7 @@
 // parser/openapi_parser.ts
 
 import { SpecIR, TableSpec, ColumnSpec, FunctionSpec, ParamSpec, HttpMethod } from '../types/specir.js';
-import fs from 'fs';
+import { readFile, access } from 'fs/promises';
 import yaml from 'js-yaml';
 import path from 'path';
 import { OpenAPIV3 } from 'openapi-types';
@@ -10,14 +10,16 @@ import { OpenAPIV3 } from 'openapi-types';
  * Parses an OpenAPI YAML or JSON file into a SpecIR intermediate model.
  * @param filePath The path to the OpenAPI spec file.
  */
-export function parseOpenAPI(filePath: string): SpecIR {
+export async function parseOpenAPI(filePath: string): Promise<SpecIR> {
   console.log(`Parsing OpenAPI spec from: ${filePath}`);
 
-  if (!fs.existsSync(filePath)) {
+  try {
+    await access(filePath);
+  } catch {
     throw new Error(`OpenAPI file not found: ${filePath}`);
   }
 
-  const fileContent = fs.readFileSync(filePath, 'utf-8');
+  const fileContent = await readFile(filePath, 'utf-8');
   let openapiDoc: OpenAPIV3.Document;
   try {
     openapiDoc = yaml.load(fileContent) as OpenAPIV3.Document;

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,9 +1,14 @@
 import path from 'path';
 import { parseOpenAPI } from '../parser/openapi_parser';
+import { SpecIR } from '../types/specir';
 
 describe('parseOpenAPI', () => {
   const specPath = path.join(__dirname, 'petstore.yaml');
-  const spec = parseOpenAPI(specPath);
+  let spec: SpecIR;
+
+  beforeAll(async () => {
+    spec = await parseOpenAPI(specPath);
+  });
 
   test('parses tables', () => {
     expect(spec.tables).toEqual([
@@ -60,20 +65,24 @@ describe('parseOpenAPI', () => {
     });
   });
 
-  test('throws a clear error when file is missing', () => {
+  test('throws a clear error when file is missing', async () => {
     const badPath = path.join(__dirname, 'missing_file.yaml');
-    expect(() => parseOpenAPI(badPath)).toThrowError('OpenAPI file not found');
+    await expect(parseOpenAPI(badPath)).rejects.toThrowError('OpenAPI file not found');
   });
 
-  test('throws a clear error when YAML is invalid', () => {
+  test('throws a clear error when YAML is invalid', async () => {
     const badPath = path.join(__dirname, 'invalid.yaml');
-    expect(() => parseOpenAPI(badPath)).toThrowError(/Failed to parse OpenAPI file:/);
+    await expect(parseOpenAPI(badPath)).rejects.toThrowError(/Failed to parse OpenAPI file:/);
   });
 });
 
 describe('parseOpenAPI with complex schemas', () => {
   const specPath = path.join(__dirname, 'complex.yaml');
-  const spec = parseOpenAPI(specPath);
+  let spec: SpecIR;
+
+  beforeAll(async () => {
+    spec = await parseOpenAPI(specPath);
+  });
 
   test('handles array and object types', () => {
     expect(spec.tables).toEqual([
@@ -92,7 +101,11 @@ describe('parseOpenAPI with complex schemas', () => {
 
 describe('parseOpenAPI with referenced parameters', () => {
   const specPath = path.join(__dirname, 'ref-params.yaml');
-  const spec = parseOpenAPI(specPath);
+  let spec: SpecIR;
+
+  beforeAll(async () => {
+    spec = await parseOpenAPI(specPath);
+  });
 
   test('resolves parameter references', () => {
     expect(spec.functions).toContainEqual({


### PR DESCRIPTION
## Summary
- convert `parseOpenAPI` to async/await using `fs/promises`
- update CLI and tests to handle Promise-based parser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c1ffdd448328bfc01f244e61232e