### PR TITLE
feat: support typed array responses

### DIFF
--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -110,8 +110,19 @@ function parseOperationToFunction(
   let requestBodyType: string | undefined;
   const requestBody = operation.requestBody as OpenAPIV3.RequestBodyObject | undefined;
   const reqSchema = requestBody?.content?.['application/json']?.schema;
-  if (reqSchema && '$ref' in reqSchema) {
-    requestBodyType = extractRefName(reqSchema.$ref);
+  if (reqSchema) {
+    if ('$ref' in reqSchema) {
+      requestBodyType = extractRefName(reqSchema.$ref);
+    } else if (reqSchema.type === 'array' && reqSchema.items) {
+      const items = reqSchema.items as any;
+      if ('$ref' in items) {
+        requestBodyType = `${extractRefName(items.$ref)}[]`;
+      } else if (items.type) {
+        requestBodyType = `${mapSchemaTypeToTSType(items.type)}[]`;
+      } else {
+        requestBodyType = 'any[]';
+      }
+    }
   }
 
   let responseBodyType: string | undefined;
@@ -124,9 +135,21 @@ function parseOperationToFunction(
       const response = responses[code] as OpenAPIV3.ResponseObject | OpenAPIV3.ReferenceObject;
       if ('$ref' in response) continue;
       const schema = response.content?.['application/json']?.schema;
-      if (schema && '$ref' in schema) {
-        responseBodyType = extractRefName(schema.$ref);
-        break;
+      if (schema) {
+        if ('$ref' in schema) {
+          responseBodyType = extractRefName(schema.$ref);
+          break;
+        } else if (schema.type === 'array' && schema.items) {
+          const items = schema.items as any;
+          if ('$ref' in items) {
+            responseBodyType = `${extractRefName(items.$ref)}[]`;
+          } else if (items.type) {
+            responseBodyType = `${mapSchemaTypeToTSType(items.type)}[]`;
+          } else {
+            responseBodyType = 'any[]';
+          }
+          break;
+        }
       }
     }
   }
@@ -142,11 +165,13 @@ function parseOperationToFunction(
 }
 
 function parameterObjectToParamSpec(param: OpenAPIV3.ParameterObject): ParamSpec {
+  const schema = param.schema as OpenAPIV3.SchemaObject | undefined;
   return {
     name: param.name,
     in: param.in as ParamSpec['in'],
     required: !!param.required,
-    type: (param.schema as OpenAPIV3.SchemaObject | undefined)?.type || 'string'
+    type: schema?.type || 'string',
+    schema: schema?.type === 'array' ? schema : undefined
   };
 }
 
@@ -199,6 +224,22 @@ function mapOpenAPITypeToSQLType(propSchema: any): string {
  */
 function extractRefName(ref: string): string {
   return path.basename(ref);
+}
+
+// Map primitive schema types to TS types
+function mapSchemaTypeToTSType(type: string): string {
+  switch (type) {
+    case 'string':
+      return 'string';
+    case 'integer':
+      return 'number';
+    case 'number':
+      return 'number';
+    case 'boolean':
+      return 'boolean';
+    default:
+      return 'any';
+  }
 }
 
 /**

--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -135,9 +135,10 @@ describe('generation functions', () => {
   test('generateUseHook', () => {
     const hook = generateUseHook(func);
     expect(hook).toContain("import { useQuery } from '@tanstack/react-query';");
+    expect(hook).toContain("import type { Pet } from '../types';");
     expect(hook).not.toContain('useMutation');
     expect(hook).toContain('useGetPetById');
-    expect(hook).toContain("useQuery({ queryKey: ['getPetById']");
+    expect(hook).toContain("useQuery<Pet>({ queryKey: ['getPetById']");
     expect(hook).toContain("fetch(`/pets/${encodeURIComponent(params.id)}${query ? '?' + query : ''}`);");
   });
 
@@ -166,6 +167,12 @@ describe('generation functions', () => {
     expect(buildQuery({ tag: undefined, limit: 5 })).toBe('limit=5');
     expect(buildQuery({ tag: 'cute', limit: undefined })).toBe('tag=cute');
     expect(buildQuery({ tag: undefined, limit: undefined })).toBe('');
+  });
+
+  test('generateUseHook returns typed array', () => {
+    const hook = generateUseHook(funcWithQuery);
+    expect(hook).toContain("import type { Pet } from '../types';");
+    expect(hook).toContain('useQuery<Pet[]>');
   });
 
   test('generateUseHook includes typed body', () => {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -40,6 +40,15 @@ describe('parseOpenAPI', () => {
     });
 
     expect(spec.functions).toContainEqual({
+      name: 'listPets',
+      method: 'GET',
+      path: '/pets',
+      params: [],
+      requestBodyType: undefined,
+      responseBodyType: 'Pet[]',
+    });
+
+    expect(spec.functions).toContainEqual({
       name: 'createPet201',
       method: 'POST',
       path: '/pets-creation',

--- a/tests/petstore.yaml
+++ b/tests/petstore.yaml
@@ -32,6 +32,17 @@ paths:
         '204':
           description: No Content
   /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
     post:
       operationId: createPet
       requestBody:

--- a/types/specir.ts
+++ b/types/specir.ts
@@ -36,6 +36,8 @@ export interface ParamSpec {
   in: 'path' | 'query' | 'header' | 'cookie';
   required: boolean;
   type: string; // e.g., "string", "integer"
+  // Original schema object for advanced typing (e.g., arrays)
+  schema?: any;
 }
 
 // Enumerates supported HTTP methods


### PR DESCRIPTION
## Summary
- handle array schemas in parser to track element types
- generate React Query hooks with typed array responses and deduplicated imports
- ensure mapTypeToTS resolves `$ref` arrays to `Type[]`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c204eae48328b50eada5c2dc30d5