### PR TITLE
Warn when no update fields

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -168,14 +168,14 @@ describe('generation functions', () => {
 
   test('generateCreateFunctionSQL for PUT with only id param', () => {
     const sql = generateCreateFunctionSQL(updateFuncNoParams);
-    expect(sql).toContain('UPDATE Pet SET -- no columns to update WHERE id = _id');
-    expect(sql).toContain('RETURNING *');
+    expect(sql).toContain('-- Warning: no columns provided to update');
+    expect(sql).not.toContain('RETURNING *');
   });
 
   test('generateCreateFunctionSQL for PATCH with only id param', () => {
     const sql = generateCreateFunctionSQL(patchFuncNoParams);
-    expect(sql).toContain('UPDATE Pet SET -- no columns to update WHERE id = _id');
-    expect(sql).toContain('RETURNING *');
+    expect(sql).toContain('-- Warning: no columns provided to update');
+    expect(sql).not.toContain('RETURNING *');
   });
 
   test('generateCreateFunctionSQL for DELETE', () => {

--- a/transformer/db_transformer.ts
+++ b/transformer/db_transformer.ts
@@ -89,12 +89,19 @@ function generateFunctionBodySQL(func: FunctionSpec, tableName: string): string 
     case 'PATCH': {
       if (paramNames.length) {
         const [idParam, ...rest] = paramNames;
-        const setClause = rest.length
-          ? rest.map(name => `${name} = ${placeholders[name]}`).join(', ')
-          : '-- no columns to update';
+        if (rest.length === 0) {
+          const warning = `-- Warning: no columns provided to update for ${tableName}`;
+          console.warn(warning);
+          return warning;
+        }
+        const setClause = rest
+          .map(name => `${name} = ${placeholders[name]}`)
+          .join(', ');
         return `UPDATE ${tableName} SET ${setClause} WHERE ${idParam} = ${placeholders[idParam]}${func.responseBodyType ? ' RETURNING *' : ''};`;
       }
-      return `UPDATE ${tableName} SET -- no parameters provided${func.responseBodyType ? ' RETURNING *' : ''};`;
+      const warning = `-- Warning: no parameters provided for ${tableName} update`;
+      console.warn(warning);
+      return warning;
     }
     case 'DELETE': {
       const whereClause = paramNames.length


### PR DESCRIPTION
## Summary
- avoid emitting UPDATE when no columns supplied
- adjust generation tests for warning-only behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e6b59f6083288c44845cf6b1c3f2