### PR TITLE
feat: handle query response

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -199,6 +199,9 @@ describe('generation functions', () => {
     expect(hook).toContain('useGetPetById');
     expect(hook).toContain("useQuery<Pet>({ queryKey: ['getPetById']");
     expect(hook).toContain("fetch(`/pets/${encodeURIComponent(params.id)}${query ? '?' + query : ''}`);");
+    expect(hook).toContain('if (!response.ok)');
+    expect(hook).toContain("throw new Error('Network response was not ok')");
+    expect(hook).toContain('return response.json();');
   });
 
   test('generateUseHook encodes path params', () => {
@@ -238,5 +241,14 @@ describe('generation functions', () => {
     const hook = generateUseHook(createFunc);
     expect(hook).toContain("import type { Pet } from '../types';");
     expect(hook).toContain('body: Pet');
+  });
+
+  test('generateUseHook without response body', () => {
+    const hook = generateUseHook(deleteFunc);
+    expect(hook).toContain("import { useMutation } from '@tanstack/react-query';");
+    expect(hook).toContain('if (!response.ok)');
+    expect(hook).toContain("throw new Error('Network response was not ok')");
+    expect(hook).toContain('return undefined;');
+    expect(hook).not.toContain('response.json()');
   });
 });

--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -21,7 +21,8 @@ export function generateUseHook(func: FunctionSpec): string {
 
   const urlPath = buildUrlTemplate(func.path, urlParams);
 
-    const queryFn = func.method === 'GET'
+    const responseHandling = `if (!response.ok) {\n      throw new Error('Network response was not ok');\n    }\n    ${func.responseBodyType ? 'return response.json();' : 'return undefined;'}\n  `;
+  const queryFn = func.method === 'GET'
     ? `async () => {
     const queryParamsObj = ${queryParams.length > 0
       ? `Object.fromEntries(Object.entries({ ${queryParams
@@ -30,7 +31,7 @@ export function generateUseHook(func: FunctionSpec): string {
       : '{}'};
     const query = new URLSearchParams(queryParamsObj).toString();
     const response = await fetch(\`${urlPath}\${query ? '?' + query : ''}\`);
-    return response.json();
+    ${responseHandling}
   }`
     : `async () => {
     const response = await fetch(\`${urlPath}\`, {
@@ -38,7 +39,7 @@ export function generateUseHook(func: FunctionSpec): string {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(params.body)
     });
-    return response.json();
+    ${responseHandling}
   }`;
 
   const importList = func.method === 'GET' ? 'useQuery' : 'useMutation';


### PR DESCRIPTION
## Summary
- handle error responses when generating fetch query functions
- avoid parsing JSON when no response body is expected
- test query generation for error handling and undefined responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e6b65cf08328a138d031fe5441d9