### PR TITLE
feat: support additional HTTP methods

### DIFF
--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -45,7 +45,7 @@ export async function parseOpenAPI(filePath: string): Promise<SpecIR> {
   // --- Parse Paths into functions ---
   if (openapiDoc.paths) {
     for (const [pathKey, pathItem] of Object.entries(openapiDoc.paths as Record<string, OpenAPIV3.PathItemObject>)) {
-      for (const method of ['get', 'post', 'put', 'patch', 'delete'] as const) {
+      for (const method of ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'] as const) {
         const operation = pathItem[method];
         if (operation) {
           const func = parseOperationToFunction(

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -63,6 +63,24 @@ describe('parseOpenAPI', () => {
     });
 
     expect(spec.functions).toContainEqual({
+      name: 'headPets',
+      method: 'HEAD',
+      path: '/pets',
+      params: [],
+      requestBodyType: undefined,
+      responseBodyType: undefined,
+    });
+
+    expect(spec.functions).toContainEqual({
+      name: 'optionsPets',
+      method: 'OPTIONS',
+      path: '/pets',
+      params: [],
+      requestBodyType: undefined,
+      responseBodyType: undefined,
+    });
+
+    expect(spec.functions).toContainEqual({
       name: 'deletePet',
       method: 'DELETE',
       path: '/pets/{id}',

--- a/tests/petstore.yaml
+++ b/tests/petstore.yaml
@@ -43,6 +43,16 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Pet'
+    head:
+      operationId: headPets
+      responses:
+        '200':
+          description: OK
+    options:
+      operationId: optionsPets
+      responses:
+        '200':
+          description: OK
     post:
       operationId: createPet
       requestBody:

--- a/transformer/db_transformer.ts
+++ b/transformer/db_transformer.ts
@@ -108,6 +108,7 @@ function generateFunctionBodySQL(func: FunctionSpec, tableName: string): string 
     }
     case 'HEAD':
     case 'OPTIONS':
+    case 'TRACE':
     default:
       return `-- Unsupported HTTP method: ${func.method}`;
   }

--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -21,8 +21,9 @@ export function generateUseHook(func: FunctionSpec): string {
 
   const urlPath = buildUrlTemplate(func.path, urlParams);
 
-    const queryFn = func.method === 'GET'
-    ? `async () => {
+  const queryFn =
+    func.method === 'GET'
+      ? `async () => {
     const queryParamsObj = ${queryParams.length > 0
       ? `Object.fromEntries(Object.entries({ ${queryParams
           .map(p => `${p.name}: params.${p.name}`)
@@ -32,11 +33,9 @@ export function generateUseHook(func: FunctionSpec): string {
     const response = await fetch(\`${urlPath}\${query ? '?' + query : ''}\`);
     return response.json();
   }`
-    : `async () => {
+      : `async (${needsParams ? 'params' : ''}) => {
     const response = await fetch(\`${urlPath}\`, {
-      method: '${func.method}',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params.body)
+      method: '${func.method}'${func.requestBodyType ? `,\n      headers: { 'Content-Type': 'application/json' },\n      body: JSON.stringify(params.body)` : ''}
     });
     return response.json();
   }`;

--- a/types/specir.ts
+++ b/types/specir.ts
@@ -41,4 +41,12 @@ export interface ParamSpec {
 }
 
 // Enumerates supported HTTP methods
-export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+export type HttpMethod =
+  | 'GET'
+  | 'POST'
+  | 'PUT'
+  | 'PATCH'
+  | 'DELETE'
+  | 'HEAD'
+  | 'OPTIONS'
+  | 'TRACE';


### PR DESCRIPTION
## Summary
- handle head, options, and trace operations in OpenAPI parser
- ensure downstream transformers gracefully handle extra methods
- cover parser with tests for new HTTP methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e6b1fa088328bb27030e1537ce6d