### PR TITLE
feat: generate frontend types from SpecIR

### DIFF
--- a/cli/generate.ts
+++ b/cli/generate.ts
@@ -4,6 +4,7 @@ import { parseOpenAPI } from '../parser/openapi_parser.js';
 import { generateCreateTableSQL, generateCreateFunctionSQL } from '../transformer/db_transformer.js';
 import { generateUseHook } from '../transformer/frontend_transformer.js';
 import { writeToFile } from '../generator/file_writer.js';
+import { generateTypes } from '../generator/type_writer.js';
 import { join } from 'path';
 
 const args = process.argv.slice(2);
@@ -24,6 +25,7 @@ async function main(): Promise<void> {
 
     const dbOut = join(outputBase, 'db');
     const frontendOut = join(outputBase, 'frontend/src/hooks');
+    const frontendSrcOut = join(outputBase, 'frontend/src');
 
     console.log('Generating DB schema and functions...');
     const tableWrites: Promise<void>[] = [];
@@ -47,6 +49,13 @@ async function main(): Promise<void> {
         })
       );
     }
+
+    console.log('Generating frontend types...');
+    const typesContent = generateTypes(spec);
+    const typesPath = join(frontendSrcOut, 'types.ts');
+    const typeWrite = writeToFile(typesPath, typesContent + '\n').catch(err => {
+      throw new Error(`Failed to write ${typesPath}: ${err.message}`);
+    });
 
     console.log('Generating frontend React hooks...');
     const hookFiles: string[] = [];
@@ -75,7 +84,7 @@ async function main(): Promise<void> {
       );
     }
 
-    await Promise.all([...tableWrites, ...functionWrites, ...hookWrites]);
+    await Promise.all([typeWrite, ...tableWrites, ...functionWrites, ...hookWrites]);
 
     console.log('✅ Generation complete.');
   } catch (err) {

--- a/generator/type_writer.ts
+++ b/generator/type_writer.ts
@@ -1,0 +1,54 @@
+// generator/type_writer.ts
+
+import { SpecIR } from '../types/specir.js';
+
+/**
+ * Generates a TypeScript types file from the SpecIR tables.
+ * @param spec The SpecIR containing table definitions.
+ */
+export function generateTypes(spec: SpecIR): string {
+  const parts: string[] = [];
+  for (const table of spec.tables) {
+    const fields = table.columns
+      .map(col => `  ${col.name}${col.nullable ? '?' : ''}: ${mapSqlTypeToTs(col.type)};`)
+      .join('\n');
+    parts.push(`export interface ${table.name} {\n${fields}\n}`);
+  }
+  return parts.join('\n\n');
+}
+
+/**
+ * Maps basic SQL types to TypeScript types.
+ */
+function mapSqlTypeToTs(sqlType: string): string {
+  const isArray = sqlType.endsWith('[]');
+  const base = isArray ? sqlType.slice(0, -2) : sqlType;
+  let tsType: string;
+  switch (base.toUpperCase()) {
+    case 'INTEGER':
+    case 'INT':
+    case 'FLOAT':
+    case 'DOUBLE':
+    case 'DECIMAL':
+    case 'NUMERIC':
+      tsType = 'number';
+      break;
+    case 'BOOLEAN':
+      tsType = 'boolean';
+      break;
+    case 'TIMESTAMP':
+    case 'DATE':
+    case 'TIME':
+    case 'VARCHAR':
+    case 'TEXT':
+    case 'CHAR':
+      tsType = 'string';
+      break;
+    case 'JSONB':
+      tsType = 'any';
+      break;
+    default:
+      tsType = 'any';
+  }
+  return isArray ? `${tsType}[]` : tsType;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -15,6 +15,7 @@ describe('cli generate', () => {
 
       const dbDir = path.join(tmpDir, 'db');
       const hooksDir = path.join(tmpDir, 'frontend', 'src', 'hooks');
+      const frontendSrcDir = path.join(tmpDir, 'frontend', 'src');
 
       expect(fs.existsSync(path.join(dbDir, 'Pet_table.sql'))).toBe(true);
       expect(fs.existsSync(path.join(dbDir, 'getPetById_function.sql'))).toBe(true);
@@ -23,6 +24,7 @@ describe('cli generate', () => {
       expect(fs.existsSync(path.join(hooksDir, 'useGetPetById.ts'))).toBe(true);
       expect(fs.existsSync(path.join(hooksDir, 'useCreatePet.ts'))).toBe(true);
       expect(fs.existsSync(path.join(hooksDir, 'index.ts'))).toBe(true);
+      expect(fs.existsSync(path.join(frontendSrcDir, 'types.ts'))).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -1,6 +1,7 @@
 import { generateCreateTableSQL, generateCreateFunctionSQL } from '../transformer/db_transformer';
 import { generateUseHook } from '../transformer/frontend_transformer';
-import { TableSpec, FunctionSpec } from '../types/specir';
+import { generateTypes } from '../generator/type_writer';
+import { TableSpec, FunctionSpec, SpecIR } from '../types/specir';
 
 describe('generation functions', () => {
   const table: TableSpec = {
@@ -238,5 +239,14 @@ describe('generation functions', () => {
     const hook = generateUseHook(createFunc);
     expect(hook).toContain("import type { Pet } from '../types';");
     expect(hook).toContain('body: Pet');
+  });
+
+  test('generateTypes produces interfaces', () => {
+    const spec: SpecIR = { tables: [table], functions: [] };
+    const output = generateTypes(spec);
+    expect(output).toContain('export interface Pet');
+    expect(output).toContain('id: number;');
+    expect(output).toContain('name: string;');
+    expect(output).toContain('tag?: string;');
   });
 });


### PR DESCRIPTION
## Summary
- add type writer to emit TypeScript interfaces for SpecIR tables
- integrate type generation into CLI alongside SQL and hook generation
- test type generation and ensure CLI outputs types file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e6b002e88328b4704532b9e6255d