### PR TITLE
Handle SQL mapping for array item types

### DIFF
--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -77,7 +77,8 @@ function parseSchemaToTable(name: string, schema: OpenAPIV3.SchemaObject): Table
       name: propName,
       type: mapOpenAPITypeToSQLType(propSchema),
       nullable: !requiredFields.includes(propName),
-      primaryKey: propName === 'id' // simple heuristic
+      primaryKey: propName === 'id', // simple heuristic
+      schema: propSchema.type === 'array' ? propSchema : undefined
     });
   }
 

--- a/tests/array-items.yaml
+++ b/tests/array-items.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Array Items
+  version: "1.0"
+components:
+  schemas:
+    ArrayExample:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        numbers:
+          type: array
+          items:
+            type: integer
+        flags:
+          type: array
+          items:
+            type: boolean

--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -45,6 +45,30 @@ describe('generation functions', () => {
     responseBodyType: 'Pet[]',
   };
 
+  const funcWithArrayParams: FunctionSpec = {
+    name: 'filterPets',
+    method: 'GET',
+    path: '/pets/filter',
+    params: [
+      {
+        name: 'ids',
+        in: 'query',
+        required: false,
+        type: 'array',
+        schema: { type: 'array', items: { type: 'integer' } },
+      },
+      {
+        name: 'flags',
+        in: 'query',
+        required: false,
+        type: 'array',
+        schema: { type: 'array', items: { type: 'boolean' } },
+      },
+    ],
+    requestBodyType: undefined,
+    responseBodyType: 'Pet[]',
+  };
+
   const updateFunc: FunctionSpec = {
     name: 'updatePet',
     method: 'PUT',
@@ -176,6 +200,12 @@ describe('generation functions', () => {
     const sql = generateCreateFunctionSQL(patchFuncNoParams);
     expect(sql).toContain('UPDATE Pet SET -- no columns to update WHERE id = _id');
     expect(sql).toContain('RETURNING *');
+  });
+
+  test('generateCreateFunctionSQL with array params', () => {
+    const sql = generateCreateFunctionSQL(funcWithArrayParams);
+    expect(sql).toMatch(/_ids INTEGER\[]/);
+    expect(sql).toMatch(/_flags BOOLEAN\[]/);
   });
 
   test('generateCreateFunctionSQL for DELETE', () => {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -99,9 +99,64 @@ describe('parseOpenAPI with complex schemas', () => {
         name: 'Complex',
         columns: [
           { name: 'id', type: 'INTEGER', nullable: false, primaryKey: true },
-          { name: 'tags', type: 'VARCHAR[]', nullable: true, primaryKey: false },
+          {
+            name: 'tags',
+            type: 'VARCHAR[]',
+            nullable: true,
+            primaryKey: false,
+            schema: { type: 'array', items: { type: 'string' } },
+          },
           { name: 'attributes', type: 'JSONB', nullable: true, primaryKey: false },
-          { name: 'nested', type: 'JSONB[]', nullable: true, primaryKey: false },
+          {
+            name: 'nested',
+            type: 'JSONB[]',
+            nullable: true,
+            primaryKey: false,
+            schema: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  count: { type: 'integer' },
+                },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('parseOpenAPI with array item types', () => {
+  const specPath = path.join(__dirname, 'array-items.yaml');
+  let spec: SpecIR;
+
+  beforeAll(async () => {
+    spec = await parseOpenAPI(specPath);
+  });
+
+  test('parses arrays of primitives correctly', () => {
+    expect(spec.tables).toEqual([
+      {
+        name: 'ArrayExample',
+        columns: [
+          { name: 'id', type: 'INTEGER', nullable: false, primaryKey: true },
+          {
+            name: 'numbers',
+            type: 'INTEGER[]',
+            nullable: true,
+            primaryKey: false,
+            schema: { type: 'array', items: { type: 'integer' } },
+          },
+          {
+            name: 'flags',
+            type: 'BOOLEAN[]',
+            nullable: true,
+            primaryKey: false,
+            schema: { type: 'array', items: { type: 'boolean' } },
+          },
         ],
       },
     ]);

--- a/types/specir.ts
+++ b/types/specir.ts
@@ -18,6 +18,8 @@ export interface ColumnSpec {
   type: string;   // e.g., "varchar", "integer"
   nullable: boolean;
   primaryKey?: boolean;
+  // Original schema object for advanced typing (e.g., arrays)
+  schema?: any;
 }
 
 // Represents a database function (or API operation)


### PR DESCRIPTION
## Summary
- Capture original array schemas in ColumnSpec for richer type info
- Map array item types to correct SQL types when generating functions
- Cover integer and boolean arrays in parser and transformer tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e6b0b7a083289a8a9f04da3749d8