### PR TITLE
Fix missing closure in generation test

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -282,6 +282,7 @@ describe('generation functions', () => {
     expect(output).toContain('id: number;');
     expect(output).toContain('name: string;');
     expect(output).toContain('tag?: string;');
+  });
 
   test('generateUseHook without response body', () => {
     const hook = generateUseHook(deleteFunc);


### PR DESCRIPTION
## Summary
- add the missing closing parenthesis and brace in the generateTypes test so the file parses correctly

## Testing
- npm test -- tests/generation.test.ts *(fails: transformer/frontend_transformer.ts cannot find name 'responseHandling')*

------
https://chatgpt.com/codex/tasks/task_e_68d83ab91d788328a2338d82fa1270ef