### PR TITLE
Handle inline schemas in OpenAPI parser

### DIFF
--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -126,6 +126,10 @@ function parseOperationToFunction(
       } else {
         requestBodyType = 'any[]';
       }
+    } else if (reqSchema.type) {
+      requestBodyType = mapSchemaTypeToTSType(reqSchema.type);
+    } else {
+      requestBodyType = 'any';
     }
   }
 
@@ -152,6 +156,12 @@ function parseOperationToFunction(
           } else {
             responseBodyType = 'any[]';
           }
+          break;
+        } else if (schema.type) {
+          responseBodyType = mapSchemaTypeToTSType(schema.type);
+          break;
+        } else {
+          responseBodyType = 'any';
           break;
         }
       }
@@ -241,6 +251,8 @@ function mapSchemaTypeToTSType(type: string): string {
       return 'number';
     case 'boolean':
       return 'boolean';
+    case 'object':
+      return 'Record<string, any>';
     default:
       return 'any';
   }

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -90,6 +90,15 @@ describe('parseOpenAPI', () => {
       requestBodyType: undefined,
       responseBodyType: undefined,
     });
+
+    expect(spec.functions).toContainEqual({
+      name: 'postInlineSample',
+      method: 'POST',
+      path: '/inline-sample',
+      params: [],
+      requestBodyType: 'Record<string, any>',
+      responseBodyType: 'string',
+    });
   });
 
   test('throws a clear error when file is missing', async () => {

--- a/tests/petstore.yaml
+++ b/tests/petstore.yaml
@@ -86,6 +86,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
+  /inline-sample:
+    post:
+      operationId: postInlineSample
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
 
 components:
   schemas:


### PR DESCRIPTION
## Summary
- map inline request and response schemas to TypeScript types with sensible fallbacks
- treat object schema types as records when inferring request/response bodies
- cover inline schema handling with a parser test fixture and assertion

## Testing
- npm test -- parser

------
https://chatgpt.com/codex/tasks/task_e_68d83ab5babc83289480ad33ba60e31f