### PR TITLE
Merge path-level OpenAPI parameters into operations

### DIFF
--- a/parser/openapi_parser.ts
+++ b/parser/openapi_parser.ts
@@ -46,13 +46,19 @@ export async function parseOpenAPI(filePath: string): Promise<SpecIR> {
   // --- Parse Paths into functions ---
   if (openapiDoc.paths) {
     for (const [pathKey, pathItem] of Object.entries(openapiDoc.paths as Record<string, OpenAPIV3.PathItemObject>)) {
+      const pathParameters = pathItem.parameters as (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] | undefined;
+
       for (const method of ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'] as const) {
         const operation = pathItem[method];
         if (operation) {
+          const mergedParameters = mergePathAndOperationParameters(
+            pathParameters,
+            operation.parameters as (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] | undefined
+          );
           const func = parseOperationToFunction(
             method.toUpperCase(),
             pathKey,
-            operation,
+            { ...operation, parameters: mergedParameters },
             openapiDoc.components?.parameters
           );
           functions.push(func);
@@ -97,16 +103,30 @@ function parseOperationToFunction(
 ): FunctionSpec {
   const params: ParamSpec[] = [];
 
+  const seenParams = new Map<string, number>();
+
   if (operation.parameters) {
     for (const param of operation.parameters as (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[]) {
+      let resolvedParam: OpenAPIV3.ParameterObject | undefined;
       if ('$ref' in param) {
-        const resolved = resolveParameterRef(param.$ref, globalParams);
-        if (resolved) {
-          params.push(parameterObjectToParamSpec(resolved));
-        }
+        resolvedParam = resolveParameterRef(param.$ref, globalParams);
+      } else {
+        resolvedParam = param;
+      }
+
+      if (!resolvedParam) {
         continue;
       }
-      params.push(parameterObjectToParamSpec(param));
+
+      const paramSpec = parameterObjectToParamSpec(resolvedParam);
+      const paramKey = `${resolvedParam.in}:${resolvedParam.name}`;
+
+      if (seenParams.has(paramKey)) {
+        params[seenParams.get(paramKey)!] = paramSpec;
+      } else {
+        seenParams.set(paramKey, params.length);
+        params.push(paramSpec);
+      }
     }
   }
 
@@ -166,6 +186,18 @@ function parseOperationToFunction(
     requestBodyType,
     responseBodyType
   };
+}
+
+function mergePathAndOperationParameters(
+  pathParams: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] | undefined,
+  operationParams: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] | undefined
+): (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[] | undefined {
+  const merged = [
+    ...(pathParams ?? []),
+    ...(operationParams ?? [])
+  ];
+
+  return merged.length > 0 ? merged : undefined;
 }
 
 function parameterObjectToParamSpec(param: OpenAPIV3.ParameterObject): ParamSpec {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -202,3 +202,37 @@ describe('parseOpenAPI with referenced parameters', () => {
     });
   });
 });
+
+describe('parseOpenAPI with path-level parameters', () => {
+  const specPath = path.join(__dirname, 'path-params.yaml');
+  let spec: SpecIR;
+
+  beforeAll(async () => {
+    spec = await parseOpenAPI(specPath);
+  });
+
+  test('merges path parameters into each operation', () => {
+    expect(spec.functions).toContainEqual({
+      name: 'getWidget',
+      method: 'GET',
+      path: '/widgets/{widgetId}',
+      params: [
+        { name: 'widgetId', in: 'path', required: true, type: 'string' },
+      ],
+      requestBodyType: undefined,
+      responseBodyType: undefined,
+    });
+
+    expect(spec.functions).toContainEqual({
+      name: 'updateWidget',
+      method: 'POST',
+      path: '/widgets/{widgetId}',
+      params: [
+        { name: 'widgetId', in: 'path', required: true, type: 'string' },
+        { name: 'verbose', in: 'query', required: false, type: 'boolean' },
+      ],
+      requestBodyType: undefined,
+      responseBodyType: undefined,
+    });
+  });
+});

--- a/tests/path-params.yaml
+++ b/tests/path-params.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Path Params API
+  version: 1.0.0
+paths:
+  /widgets/{widgetId}:
+    parameters:
+      - $ref: '#/components/parameters/WidgetId'
+    get:
+      operationId: getWidget
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+    post:
+      operationId: updateWidget
+      parameters:
+        - name: verbose
+          in: query
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '204':
+          description: No Content
+components:
+  parameters:
+    WidgetId:
+      name: widgetId
+      in: path
+      required: true
+      schema:
+        type: string


### PR DESCRIPTION
## Summary
- merge path-level OpenAPI parameters into each operation before converting to SpecIR functions
- ensure merged parameters are deduplicated after resolving $ref entries
- add a fixture and parser test covering path-level parameters

## Testing
- npm test *(fails: existing responseHandling reference error in cli test)*

------
https://chatgpt.com/codex/tasks/task_e_68d83ab524ec8328ae65070fe01b9b23