### PR TITLE
Map non-primitive types to JSONB

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -172,6 +172,14 @@ describe('generation functions', () => {
     expect(sql).toMatch(/getPetById\(_id INTEGER\)/);
   });
 
+  test('generateCreateFunctionSQL maps non-primitive return types to JSONB', () => {
+    const sql = generateCreateFunctionSQL(func);
+    expect(sql).toContain('RETURNS JSONB');
+
+    const arraySql = generateCreateFunctionSQL(funcWithQuery);
+    expect(arraySql).toContain('RETURNS JSONB[]');
+  });
+
   test('generateCreateFunctionSQL for POST', () => {
     const sql = generateCreateFunctionSQL(createFunc);
     expect(sql).toContain('INSERT INTO Pet (id, name) VALUES (_id, _name)');
@@ -282,6 +290,7 @@ describe('generation functions', () => {
     expect(output).toContain('id: number;');
     expect(output).toContain('name: string;');
     expect(output).toContain('tag?: string;');
+  });
 
   test('generateUseHook without response body', () => {
     const hook = generateUseHook(deleteFunc);

--- a/transformer/db_transformer.ts
+++ b/transformer/db_transformer.ts
@@ -151,6 +151,9 @@ function mapTypeToSQL(type: string, schema?: any): string {
     case 'number':
       return 'FLOAT';
     default:
+      if (/^[A-Z]/.test(type)) {
+        return 'JSONB';
+      }
       return 'TEXT';
   }
 }

--- a/transformer/frontend_transformer.ts
+++ b/transformer/frontend_transformer.ts
@@ -22,6 +22,16 @@ export function generateUseHook(func: FunctionSpec): string {
 
   const urlPath = buildUrlTemplate(func.path, urlParams);
 
+  const responseHandling = func.responseBodyType
+    ? `if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    return response.json();`
+    : `if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    return undefined;`;
+
   const queryFn =
     func.method === 'GET'
       ? `async () => {


### PR DESCRIPTION
## Summary
- map capitalized function return types to JSONB, including array support
- add missing response handling template used by generated hooks
- cover JSONB return mapping with new generation test cases

## Testing
- npm test -- generation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d83ab6fe848328a8b1f29c01b53d54