### PR TITLE
Sanitize table inference for inline types

### DIFF
--- a/tests/generation.test.ts
+++ b/tests/generation.test.ts
@@ -156,6 +156,24 @@ describe('generation functions', () => {
     responseBodyType: 'Pet',
   };
 
+  const inlineRequestFunc: FunctionSpec = {
+    name: 'createInlineReport',
+    method: 'POST',
+    path: '/reports/summary',
+    params: [],
+    requestBodyType: 'Record<string, any>',
+    responseBodyType: undefined,
+  };
+
+  const inlineResponseFunc: FunctionSpec = {
+    name: 'getInlineReport',
+    method: 'GET',
+    path: '/reports/summary',
+    params: [],
+    requestBodyType: undefined,
+    responseBodyType: 'Record<string, any>',
+  };
+
   test('generateCreateTableSQL', () => {
     const sql = generateCreateTableSQL(table);
     expect(sql).toBe(`CREATE TABLE IF NOT EXISTS Pet (
@@ -180,11 +198,23 @@ describe('generation functions', () => {
     expect(arraySql).toContain('RETURNS JSONB[]');
   });
 
+  test('generateCreateFunctionSQL falls back to sanitized path name for inline response type', () => {
+    const sql = generateCreateFunctionSQL(inlineResponseFunc);
+    expect(sql).toContain('SELECT * FROM ReportsSummary');
+    expect(sql).not.toContain('FROM Recordstringany');
+  });
+
   test('generateCreateFunctionSQL for POST', () => {
     const sql = generateCreateFunctionSQL(createFunc);
     expect(sql).toContain('INSERT INTO Pet (id, name) VALUES (_id, _name)');
     expect(sql).toMatch(/createPet\(_id INTEGER, _name VARCHAR\)/);
     expect(sql).toContain('RETURNING *');
+  });
+
+  test('generateCreateFunctionSQL falls back to sanitized path name for inline request type', () => {
+    const sql = generateCreateFunctionSQL(inlineRequestFunc);
+    expect(sql).toContain('INSERT INTO ReportsSummary');
+    expect(sql).not.toContain('INSERT INTO Recordstringany');
   });
 
   test('generateCreateFunctionSQL for PUT', () => {

--- a/types/specir.ts
+++ b/types/specir.ts
@@ -30,6 +30,7 @@ export interface FunctionSpec {
   params: ParamSpec[];         // URL parameters, query parameters, etc.
   requestBodyType?: string;    // For POST/PUT/PATCH
   responseBodyType?: string;   // Type returned on success
+  entityName?: string;         // Preferred entity/table identifier inferred from the spec
 }
 
 // Represents a single parameter

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -1,3 +1,17 @@
 export function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
+
+export function sanitizeIdentifier(raw: string | undefined | null): string {
+  if (!raw) {
+    return '';
+  }
+
+  const withoutArraySuffix = raw.replace(/\[\]$/, '');
+  const stripped = withoutArraySuffix.replace(/[^A-Za-z0-9_]/g, '');
+  if (!stripped) {
+    return '';
+  }
+
+  return /^[0-9]/.test(stripped) ? `_${stripped}` : stripped;
+}


### PR DESCRIPTION
## Summary
- sanitize inferred table names so functions with inline schemas fall back to clean, path-derived identifiers
- enrich FunctionSpec parsing with entity names sourced from known tables or sanitized path segments
- add regression tests covering inline request and response object handling

## Testing
- npm test -- --runTestsByPath tests/generation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_69020dab646883289cc248deb04961eb